### PR TITLE
fix(metrics.refreshMetrics): remove metrics if no backup exists anymore

### DIFF
--- a/pg253/metrics.py
+++ b/pg253/metrics.py
@@ -67,10 +67,20 @@ class Metrics:
 
     def refreshMetrics(self):
         for database in Remote.BACKUPS:
-            (self.first_backup.labels(database)
-             .set(min(Remote.BACKUPS[database], default=0)[0].timestamp()))
-            (self.last_backup.labels(database)
-             .set(max(Remote.BACKUPS[database], default=0)[0].timestamp()))
+            if len(Remote.BACKUPS[database]) > 0:
+                (self.first_backup.labels(database)
+                 .set(min(Remote.BACKUPS[database], default=[])[0].timestamp()))
+                (self.last_backup.labels(database)
+                 .set(max(Remote.BACKUPS[database], default=[])[0].timestamp()))
+            else:
+                try:
+                    self.first_backup.remove(database)
+                except KeyError:
+                    pass # Metric may not exists
+                try:
+                    self.last_backup.remove(database)
+                except KeyError:
+                    pass # Metric may not exists
 
     def removeBackup(self, database, date, size):
         self.backups.remove(database, date.strftime('%Y%m%d-%H%M'), size)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,91 @@
+"""Module for testing the metrics module"""
+
+import sys
+from datetime import datetime
+
+from unittest.mock import patch, MagicMock
+from prometheus_client import REGISTRY, CollectorRegistry
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    """Actions to run before and after each test"""
+    collector = CollectorRegistry(auto_describe=True)
+    REGISTRY.register(collector)
+    yield
+    collectors = list(REGISTRY._collector_to_names.keys()) # pylint: disable=W0212
+    for collector in collectors:
+        REGISTRY.unregister(collector)
+
+@patch('prometheus_client.start_http_server', autospec=True)
+def test_refresh_metrics_ok(_):
+    """Test Metrics.refreshMetrics() with valid parameters"""
+    mock_remote = MagicMock()
+    current_time = datetime.now()
+    mock_remote.BACKUPS = {"foo": [(current_time, 10)]}
+
+    metric_labels = {'database': 'foo'}
+
+    with patch.dict("sys.modules", {"pg253.remote": MagicMock(Remote=mock_remote)}):
+        if "pg253.metrics" in sys.modules:
+            del sys.modules['pg253.metrics']
+
+        from pg253.metrics import Metrics # pylint: disable=C0415
+        m = Metrics()
+        m.refreshMetrics()
+
+        assert REGISTRY.get_sample_value('first_backup', metric_labels) == current_time.timestamp()
+        assert REGISTRY.get_sample_value('last_backup', metric_labels) == current_time.timestamp()
+
+
+@patch('prometheus_client.start_http_server', autospec=True)
+def test_refresh_metrics_databases_and_backups_removed(_):
+    """Test Metrics.refreshMetrics() when database and all backups have been removed"""
+    mock_remote = MagicMock()
+    current_time = datetime.now()
+    mock_remote.BACKUPS = {"foo": [(current_time, 10)]}
+
+    metric_labels = {'database': 'foo'}
+
+    with patch.dict("sys.modules", {"pg253.remote": MagicMock(Remote=mock_remote)}):
+        if "pg253.metrics" in sys.modules:
+            del sys.modules['pg253.metrics']
+
+        from pg253.metrics import Metrics # pylint: disable=C0415
+        m = Metrics()
+        m.refreshMetrics()
+
+        # We have a database backup, we should have metrics
+        assert REGISTRY.get_sample_value('first_backup', metric_labels) == current_time.timestamp()
+        assert REGISTRY.get_sample_value('last_backup', metric_labels) == current_time.timestamp()
+
+        mock_remote.BACKUPS = {"foo": []}
+        m.refreshMetrics()
+
+        # We removed database's backups, we shouldn't have metrics anymore
+        assert REGISTRY.get_sample_value('first_backup', metric_labels) is None
+        assert REGISTRY.get_sample_value('last_backup', metric_labels) is None
+
+@patch('prometheus_client.start_http_server', autospec=True)
+def test_refresh_metrics_database_but_no_backup(_):
+    """Test Metrics.refreshMetrics() when database exists but no backup exists"""
+    mock_remote = MagicMock()
+    current_time = datetime.now()
+    mock_remote.BACKUPS = {"foo": []}
+
+    metric_labels = {'database': 'foo'}
+
+    with patch.dict("sys.modules", {"pg253.remote": MagicMock(Remote=mock_remote)}):
+        if "pg253.metrics" in sys.modules:
+            del sys.modules['pg253.metrics']
+
+        from pg253.metrics import Metrics # pylint: disable=C0415
+        m = Metrics()
+
+        # Removing non-existing metrics shouldn't raise an error
+        m.refreshMetrics()
+
+        # Metrics should not exist
+        assert REGISTRY.get_sample_value('first_backup', metric_labels) is None
+        assert REGISTRY.get_sample_value('last_backup', metric_labels) is None


### PR DESCRIPTION
Regularly, we run into this exception when databases are created and removed after PG253 has been deployed:
```
Job "Cluster.backup_and_prune (trigger: cron[month='*', day='*', day_of_week='*', hour='1', minute='1'], next run at: 2025-02-09 01:01:00 UTC)" raised an exception
Traceback (most recent call last):
  File "apscheduler/executors/base.py", line 131, in run_job
  File "pg253/cluster.py", line 41, in backup_and_prune
  File "pg253/cluster.py", line 35, in backup_and_prune
  File "pg253/cluster.py", line 65, in prune
  File "pg253/metrics.py", line 77, in removeBackup
  File "pg253/metrics.py", line 71, in refreshMetrics
TypeError: 'int' object is not subscriptable
```

This PR aims to fix the exception on the `refreshMetrics()` function by only updating existing metrics. I also added a test suite to make debugging easier.